### PR TITLE
.github/CONTRIBUTING.md: Fix link to brew contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 # Contributing to homebrew-extra
 
-Please follow the [general Linuxbrew contribution guidelines](https://github.com/linuxbrew/brew/blob/master/.github/CONTRIBUTING.md).
+Please follow the [general Linuxbrew contribution guidelines](https://github.com/linuxbrew/brew/blob/master/CONTRIBUTING.md).
 
 Thanks!


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-extra/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?