### PR TITLE
quick and dirty fix for CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: linuxbrew/linuxbrew
     environment:
+      CIRCLE_PROJECT_USERNAME: linuxbrew
       CIRCLE_REPOSITORY_URL: https://github.com/linuxbrew/homebrew-extra
       HOMEBREW_DEVELOPER: 1
       HOMEBREW_NO_AUTO_UPDATE: 1


### PR DESCRIPTION
Fixing CircleCI config file.
Situation: there are 2 folders, namely `Linuxbrew` and `linuxbrew`, under ~/.linuxbrew/Homebrew/Library/Taps...

I'm not sure that will fix the problem. Will have to restart the  test with SSH enabled.