### PR TITLE
man-db: update to 2.8.3

### DIFF
--- a/Formula/man-db.rb
+++ b/Formula/man-db.rb
@@ -1,9 +1,8 @@
 class ManDb < Formula
   desc "Unix documentation system"
   homepage "http://man-db.nongnu.org/"
-  url "https://download.savannah.gnu.org/releases/man-db/man-db-2.7.6.1.tar.xz"
-  sha256 "08edbc52f24aca3eebac429b5444efd48b9b90b9b84ca0ed5507e5c13ed10f3f"
-  revision 1
+  url "https://download.savannah.gnu.org/releases/man-db/man-db-2.8.3.tar.xz"
+  sha256 "5932a1ca366e1ec61a3ece1a3afa0e92f2fdc125b61d236f20cc6ff9d80cc4ac"
 
   bottle do
     sha256 "a02d6504d21b5b08f05477d63f9503ef7ec981ccdf2b976a8b69d2c859d1b879" => :x86_64_linux
@@ -18,6 +17,7 @@ class ManDb < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "libpipeline"
+
   unless OS.mac?
     depends_on "gdbm"
     depends_on "groff"


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-extra/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [ ] Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

Updating `man-db` to 2.8.3