### PR TITLE
aws-vault: 4.6.0 (new formula)

### DIFF
--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -4,6 +4,11 @@ class AwsVault < Formula
   url "https://github.com/99designs/aws-vault/archive/v4.6.0.tar.gz"
   sha256 "058f20dcfafad2641c35b6970909d0dedd71db66450d820f8f1fb457abcf50a0"
 
+  bottle do
+    cellar :any_skip_relocation
+    sha256 "99a3988e3a2134ae486c1cc8f3aa1e7e12f70c845c7d465d04c5267183a28fc8" => :x86_64_linux
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -1,0 +1,23 @@
+class AwsVault < Formula
+  desc "Securely store and access AWS credentials in development environments"
+  homepage "https://github.com/99designs/aws-vault"
+  url "https://github.com/99designs/aws-vault/archive/v4.6.0.tar.gz"
+  sha256 "058f20dcfafad2641c35b6970909d0dedd71db66450d820f8f1fb457abcf50a0"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOOS"] = "linux"
+    ENV["GOARCH"] = "amd64"
+
+    system "make", "build"
+    bin.install "aws-vault"
+
+    zsh_completion.install "completions/zsh/_aws-vault"
+    bash_completion.install "completions/bash/aws-vault"
+  end
+
+  test do
+    assert_match("aws-vault: error: required argument 'profile' not provided, try --help", shell_output("#{bin}/aws-vault login 2>&1", 1))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-extra/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] ~Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?~
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

- On MacOS, `aws-vault` is a Cask because it needs code signing to work
  with the MacOS keychain.
- Casks don't install on Linux, and the CodeSigning restrictions don't
  apply on Linux because of the lack of a MacOS keychain. ;-)
- We can have a Linux-only formula in this tap, as it will never get
  into -core because -core inherits from upstream Homebrew.