### PR TITLE
minikube: 1.2.0 (new formula)

### DIFF
--- a/Formula/minikube.rb
+++ b/Formula/minikube.rb
@@ -1,0 +1,20 @@
+class Minikube < Formula
+  desc "Run a Kubernetes cluster locally"
+  homepage "https://github.com/kubernetes/minikube"
+  url "https://github.com/kubernetes/minikube/archive/v1.2.0.tar.gz"
+  sha256 "34544176451a9dbddf0ff053285efecbef69942e1b4a103452862dc6ee31ebd4"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOOS"] = "linux"
+    ENV["GOARCH"] = "amd64"
+
+    system "make"
+    bin.install "out/minikube"
+  end
+
+  test do
+    assert_match("config modifies minikube config files using subcommands like \"minikube config set vm-driver kvm\"", shell_output("#{bin}/minikube config"))
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-extra/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] ~Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?~
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

- Minikube, like aws-vault, was only available in Homebrew Cask for MacOS.
- This adds a formula that builds on Linux (tested on Ubuntu 18.04).