### PR TITLE
aws-vault: Fix empty version string

### DIFF
--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -15,7 +15,9 @@ class AwsVault < Formula
     ENV["GOOS"] = "linux"
     ENV["GOARCH"] = "amd64"
 
-    system "make", "build"
+    flags = "-X main.Version=#{version} -s -w"
+
+    system "go", "build", "-ldflags=#{flags}"
     bin.install "aws-vault"
 
     zsh_completion.install "completions/zsh/_aws-vault"

--- a/Formula/aws-vault.rb
+++ b/Formula/aws-vault.rb
@@ -3,6 +3,7 @@ class AwsVault < Formula
   homepage "https://github.com/99designs/aws-vault"
   url "https://github.com/99designs/aws-vault/archive/v4.6.1.tar.gz"
   sha256 "7e4a6195fdbdf4a4e9bac4ce790d7463bba03da0cdcc81fcbca3dd9415027f1e"
+  revision 1
 
   bottle do
     cellar :any_skip_relocation


### PR DESCRIPTION
- [x] Have you followed the guidelines in our [Contributing](https://github.com/Linuxbrew/homebrew-extra/blob/master/.github/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Linuxbrew/homebrew-xorg/pulls) for the same update/change?
- [x] ~Have you included a log of the failed build without your patch using `brew gist-logs <formula>`?~
- [x] Does your submission pass
`brew audit --strict <formula>` (where `<formula>` is the name of the formula you're submitting)?
- [x] Have you built your formula locally prior to submission with `brew install <formula>`?

---

- Fixes #59.
- In issue 59, I noticed that `aws-vault --version` didn't output anything.
- This is because in the
  [Makefie](https://github.com/99designs/aws-vault/blob/master/Makefile#L2),
  it tries to do a `git describe --tags` which doesn't work because the
  tarball is not a Git repo, which results in:
  ```
  fatal: not a git repository (or any of the parent directories): .git
  go build -o aws-vault -ldflags="-X main.Version= -s -w" .
  ```
- Instead, set a `flags` variable that's passed into `go build` that
  includes the version string.
- This is, I think, preferable to setting this formula up to pull from a
  GitHub tag, as that needs more updating when a tag is released because
  `tag`s require `revision`s to pass the audit.

---

Before:

```
$ aws-vault --version


```

After:

```
$ aws-vault --version
4.6.1
```